### PR TITLE
feat: Implement public user profile view

### DIFF
--- a/app/src/main/java/de/hsb/vibeify/core/Destinations.kt
+++ b/app/src/main/java/de/hsb/vibeify/core/Destinations.kt
@@ -20,6 +20,8 @@ enum class Destinations(val route: String) {
     SearchView("search_view"),
     ProfileView("profile_view/{userId}"),
 
+    PublicPlaylistView("public_playlist_view/{playlistId}"),
+
     PlaybackView("playback_view"),
 
 }

--- a/app/src/main/java/de/hsb/vibeify/core/Navigation.kt
+++ b/app/src/main/java/de/hsb/vibeify/core/Navigation.kt
@@ -43,6 +43,7 @@ import de.hsb.vibeify.ui.login.LoginView
 import de.hsb.vibeify.ui.playlist.PlaylistView
 import de.hsb.vibeify.ui.playlist.detail.PlaylistDetailView
 import de.hsb.vibeify.ui.profile.ProfileView
+import de.hsb.vibeify.ui.publicProfile.PublicProfileView
 import de.hsb.vibeify.ui.register.RegisterView
 import de.hsb.vibeify.ui.search.SearchView
 import java.net.URLDecoder
@@ -165,6 +166,16 @@ fun RootNavHost() {
                         NavbarDestinations.PROFILE -> ProfileView(navController = navController)
                     }
                 }
+            }
+            composable(
+                route = Destinations.PublicPlaylistView.route,
+                arguments = listOf(navArgument("userId") { type = NavType.StringType })
+            ) {
+                PublicProfileView(
+                    modifier = Modifier,
+                    navController = navController,
+                    userId = it.arguments?.getString("userId") ?: ""
+                )
             }
             composable(
                 route = Destinations.PlaylistDetailView.route,

--- a/app/src/main/java/de/hsb/vibeify/ui/profile/EditProfileDialog.kt
+++ b/app/src/main/java/de/hsb/vibeify/ui/profile/EditProfileDialog.kt
@@ -3,14 +3,10 @@ package de.hsb.vibeify.ui.profile
 import android.provider.Contacts
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -21,12 +17,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
-import de.hsb.vibeify.ui.components.Avatar
 import de.hsb.vibeify.ui.components.photoPicker.PickPhoto
 
 @OptIn(UnstableApi::class)

--- a/app/src/main/java/de/hsb/vibeify/ui/publicProfile/PublicProfileView.kt
+++ b/app/src/main/java/de/hsb/vibeify/ui/publicProfile/PublicProfileView.kt
@@ -1,0 +1,165 @@
+package de.hsb.vibeify.ui.publicProfile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import de.hsb.vibeify.R
+import de.hsb.vibeify.ui.components.Avatar
+import de.hsb.vibeify.ui.components.PlaylistCard
+
+@Composable
+fun PublicProfileView(
+    modifier: Modifier = Modifier,
+    userId: String,
+    viewModel: PublicProfileViewModel = hiltViewModel(),
+    navController: NavController
+) {
+
+    LaunchedEffect(userId) {
+        viewModel.loadUser(userId)
+        viewModel.loadPlaylists(userId)
+    }
+
+    val uiState = viewModel.uiState.collectAsState().value
+    val playlists = uiState.playlists
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        when {
+            uiState.isLoading -> {
+                CircularProgressIndicator()
+            }
+
+            uiState.error != null -> {
+                Text(text = "Error: ${uiState.error}")
+            }
+
+            else -> {
+                Row() {
+                    if (uiState.user?.imageUrl?.isNotBlank() == true) {
+                        Avatar(
+                            modifier = Modifier
+                                .padding(bottom = 16.dp, top = 16.dp)
+                                .size(170.dp),
+                            initials = "JL",
+                            imageUrl = uiState.user.imageUrl,
+                        )
+                    } else {
+                        Avatar(
+                            modifier = Modifier
+                                .padding(bottom = 16.dp)
+                                .size(170.dp)
+                                .padding(top = 16.dp),
+                            initials = uiState.user?.name?.take(2) ?: "AB",
+                        )
+                    }
+
+                    uiState.user?.let { user ->
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.CenterVertically)
+                                .padding(start = 16.dp, end = 16.dp)
+                        ) {
+                            Text(
+                                text = user.name.ifBlank { user.email },
+                                modifier = Modifier.padding(start = 8.dp),
+                                fontSize = 24.sp,
+                            )
+                            Row {
+                                Text(
+                                    "Followers: ${user.followers.size}",
+                                    fontSize = 14.sp,
+                                    modifier = Modifier.padding(start = 8.dp)
+                                )
+                                Text(
+                                    "Following: ${user.following.size}",
+                                    fontSize = 14.sp,
+                                    modifier = Modifier.padding(start = 8.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+                Row {
+                    Button(
+                        onClick = {
+                            // Handle follow action here
+                        },
+                        modifier = Modifier
+                            .padding(end = 8.dp, start = 26.dp)
+                            .height(35.dp)
+                            .width(120.dp)
+
+
+                    ) {
+                        Text(
+                            text = "Follow",
+                            fontSize = 14.sp
+                        )
+
+                    }
+                }
+
+                Text(
+                    text = "Their Playlists",
+                    modifier = Modifier.padding(top = 30.dp, bottom = 8.dp),
+                    fontSize = 20.sp
+                )
+
+                if (playlists.isEmpty()) {
+                    Text(
+                        text = "This user has no playlists yet.",
+                        modifier = Modifier.padding(bottom = 16.dp, top = 10.dp),
+                        fontSize = 15.sp
+                    )
+                } else {
+                    Box(modifier = modifier) {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(playlists) {
+                                PlaylistCard(
+                                    playlistDescription = it.description ?: "",
+                                    playlistName = it.title,
+                                    playlistIcon = it.imagePath
+                                        ?: R.drawable.ic_launcher_foreground,
+                                    onClick = {
+                                        navController.navigate("playlist_detail_view/${it.id}")
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/de/hsb/vibeify/ui/publicProfile/PublicProfileViewModel.kt
+++ b/app/src/main/java/de/hsb/vibeify/ui/publicProfile/PublicProfileViewModel.kt
@@ -1,0 +1,54 @@
+package de.hsb.vibeify.ui.publicProfile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.hsb.vibeify.data.model.Playlist
+import de.hsb.vibeify.data.model.User
+import de.hsb.vibeify.data.repository.UserRepository
+import de.hsb.vibeify.services.PlaylistService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class PublicProfileUiState(
+    val user: User? = null,
+    val playlists: List<Playlist> = emptyList(), // Assuming playlists are represented by their IDs
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class PublicProfileViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val playlistService: PlaylistService
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PublicProfileUiState())
+    val uiState = _uiState.asStateFlow()
+
+
+     fun loadUser(userId: String) {
+         viewModelScope.launch {
+             _uiState.value = PublicProfileUiState(isLoading = true)
+             try {
+                 val user = userRepository.getUserById(userId)
+                 _uiState.value = PublicProfileUiState(user = user, isLoading = false)
+             } catch (e: Exception) {
+                 _uiState.value = PublicProfileUiState(error = e.message, isLoading = false)
+             }
+         }
+     }
+
+    fun loadPlaylists(userId: String) {
+        viewModelScope.launch {
+            try {
+                val playlists = playlistService.getPlaylistCreatedByUser(userId)
+                _uiState.value = _uiState.value.copy(playlists = playlists)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(error = e.message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the public user profile view (`PublicProfileView.kt`) which displays a user's information and their created playlists.

**Key Changes:**

- **`PublicProfileView.kt`:**
    - Created a new composable `PublicProfileView` that takes a `userId` as an argument.
    - Fetches user details and their playlists using `PublicProfileViewModel`.
    - Displays the user's avatar, name, follower/following counts.
    - Includes a "Follow" button (functionality to be implemented).
    - Lists the user's public playlists using `PlaylistCard`.
    - Handles loading and error states.
    - Navigates to `playlist_detail_view` when a playlist is clicked.
- **`PublicProfileViewModel.kt`:**
    - Created `PublicProfileViewModel` to manage the UI state and data fetching for the public profile.
    - Includes `PublicProfileUiState` data class to hold user data, playlists, loading state, and error messages.
    - `loadUser(userId)`: Fetches user details by ID from `UserRepository`.
    - `loadPlaylists(userId)`: Fetches playlists created by the user from `PlaylistService`.
- **Navigation:**
    - Added a new route `Destinations.PublicPlaylistView` (which seems to be a typo and should likely be `PublicProfileView`) with the path "public_playlist_view/{playlistId}" (again, likely should be `public_profile_view/{userId}`).
    - Integrated `PublicProfileView` into the navigation graph.
- **Minor Cleanup:**
    - Removed unused imports in `EditProfileDialog.kt`.